### PR TITLE
Ajout d'un script de lint et correction de types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "framer-motion": "^11.0.0",

--- a/src/components/MenuToggle.tsx
+++ b/src/components/MenuToggle.tsx
@@ -2,7 +2,9 @@
 import React from "react";
 import { motion } from "framer-motion";
 
-type Props = { open: boolean } & React.SVGProps<SVGSVGElement>;
+type Props = {
+  open: boolean;
+} & React.ComponentPropsWithoutRef<typeof motion.svg>;
 
 export default function MenuToggle({ open, ...rest }: Props) {
   return (

--- a/src/components/SidePanel.tsx
+++ b/src/components/SidePanel.tsx
@@ -1,4 +1,4 @@
- import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 
 type Props = { open: boolean; onClose: () => void; children?: React.ReactNode };


### PR DESCRIPTION
## Résumé
- ajoute un script `lint` pour la vérification TypeScript
- corrige les types de `MenuToggle` pour compatibilité avec framer-motion
- nettoie l'espace inutile en tête de `SidePanel`

## Tests
- `npm ci --silent --no-audit --no-fund`
- `npm run lint --if-present || true`
- `npm test --if-present || true`
- `npm run build --if-present || true`


------
https://chatgpt.com/codex/tasks/task_e_68b5ead50cec832497dbd4801df3053f