### PR TITLE
Corrige l'accès à la clé API en mode Vite

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -17,7 +17,8 @@ export class AIService {
   
   constructor() {
     // En production, ces valeurs viendraient des variables d'environnement
-    this.apiKey = process.env.VITE_OPENAI_API_KEY || '';
+    const envApiKey = import.meta.env?.VITE_OPENAI_API_KEY;
+    this.apiKey = typeof envApiKey === 'string' ? envApiKey : '';
     this.baseUrl = 'https://api.openai.com/v1';
   }
 


### PR DESCRIPTION
## Summary
- remplace l'accès à `process.env` par `import.meta.env` afin de charger la clé API côté navigateur sans erreur
- ajoute une vérification simple pour éviter d'utiliser une valeur non définie

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9cd13e920832492c4bb6e0d9cd7ec